### PR TITLE
fix: preserve entity states during OAuth reauth flow

### DIFF
--- a/custom_components/whoop/config_flow.py
+++ b/custom_components/whoop/config_flow.py
@@ -1,12 +1,13 @@
 """Config flow for WHOOP integration."""
 
 import logging
+from collections.abc import Mapping
 from typing import Any, Dict
 
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.config_entries import ConfigFlowResult, SOURCE_REAUTH
 from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import (
@@ -89,7 +90,12 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
         return await super().async_step_user(user_input)
 
     async def async_oauth_create_entry(self, data: Dict[str, Any]) -> ConfigFlowResult:
-        """Create an entry for the flow after successful OAuth. Set a dynamic title."""
+        """Create an entry for the flow after successful OAuth.
+
+        If this is a reauth flow, update the existing entry's token data
+        and reload instead of creating a new entry. This preserves all
+        existing entity enablement states and device associations.
+        """
         _LOGGER.debug(
             "WHOOP OAuth successful, attempting to set dynamic title for config entry."
         )
@@ -97,12 +103,15 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
         access_token = data.get("token", {}).get("access_token")
         if not access_token:
             _LOGGER.error("Access token not found in OAuth data during entry creation.")
+            if self.source == SOURCE_REAUTH:
+                return self.async_abort(reason="reauth_failed")
             return self.async_create_entry(title=self.OAUTH2_CLIENT_NAME, data=data)
 
         session = async_get_clientsession(self.hass)
         api_client = WhoopApiClient(session, access_token)
 
         entry_title_name_part = "User"
+        user_id = None
 
         try:
             profile = await api_client.get_user_profile_basic()
@@ -117,11 +126,27 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
 
                 if user_id:
                     await self.async_set_unique_id(str(user_id))
-                    self._abort_if_unique_id_configured(updates=data)
             else:
                 _LOGGER.warning("Could not fetch WHOOP profile to set a dynamic title.")
         except Exception as e:
             _LOGGER.error("Error fetching WHOOP profile for dynamic title: %s", e)
+
+        # If this is a reauth flow, update the existing entry and reload
+        # instead of creating a new one. This preserves entity states.
+        if self.source == SOURCE_REAUTH:
+            reauth_entry = self._get_reauth_entry()
+            _LOGGER.info(
+                "Reauth successful for '%s', updating existing config entry.",
+                reauth_entry.title,
+            )
+            return self.async_update_reload_and_abort(
+                reauth_entry,
+                data_updates=data,
+            )
+
+        # Normal first-time setup: prevent duplicate entries
+        if user_id:
+            self._abort_if_unique_id_configured(updates=data)
 
         entry_title = f"{entry_title_name_part}'s WHOOP"
         _LOGGER.info("Creating config entry with title '%s'", entry_title)
@@ -134,12 +159,14 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
             },
         )
 
-    async def async_step_reauth(self, entry_data: Dict[str, Any]) -> ConfigFlowResult:
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
         """Perform reauth upon an API authentication error or explicit request."""
         _LOGGER.info(
-            "[%s] Starting reauthentication flow based on entry_data.", self.handler
+            "[%s] Starting reauthentication flow for existing entry.", self.handler
         )
-        return await self.async_step_reauth_confirm(entry_data)
+        return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: Dict[str, Any] | None = None
@@ -152,7 +179,7 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
             return self.async_show_form(step_id="reauth_confirm")
 
         _LOGGER.debug(
-            "[%s] Reauth confirmed, proceeding to user step to restart auth.",
+            "[%s] Reauth confirmed, proceeding to OAuth flow to refresh tokens.",
             self.handler,
         )
         return await self.async_step_user()

--- a/custom_components/whoop/translations/en.json
+++ b/custom_components/whoop/translations/en.json
@@ -6,8 +6,13 @@
       },
       "reauth_confirm": {
         "title": "Reauthenticate WHOOP",
-        "description": "Please reauthenticate with your WHOOP account."
+        "description": "Your WHOOP authentication has expired. Please reauthenticate with your WHOOP account to restore data updates."
       }
+    },
+    "abort": {
+      "already_configured": "WHOOP is already configured for this account.",
+      "reauth_successful": "Reauthentication successful. Your WHOOP data will resume updating shortly.",
+      "reauth_failed": "Reauthentication failed. Please try again."
     }
   },
   "options": {


### PR DESCRIPTION
## Problem

When WHOOP OAuth tokens expire and Home Assistant triggers the reauth flow, the current implementation sends users through the full setup flow via `async_step_user()` → `async_oauth_create_entry()`. This calls `self.async_create_entry()` which creates a **duplicate config entry** with a new device, causing:

1. All sensors to be disabled by default (`entity_registry_enabled_default=False`) on the new device
2. Existing automations and dashboards that depend on WHOOP entities to break
3. Users having to manually delete the old entry and re-enable all 42+ sensors

## Root Cause

The `async_oauth_create_entry` method didn't distinguish between a fresh setup and a reauth flow. While `_abort_if_unique_id_configured(updates=data)` was called, the reauth context was not properly handled — the method should have used `async_update_reload_and_abort` to update the existing entry's token data in-place rather than creating a new entry.

## Fix

- `async_oauth_create_entry` now checks `self.source == SOURCE_REAUTH`
- When in reauth context, it uses `self.async_update_reload_and_abort(self._get_reauth_entry(), data_updates=data)` to update the existing entry's OAuth tokens without creating a new device or resetting entity enablement states
- `async_step_reauth` parameter type updated to `Mapping[str, Any]` per HA Core conventions
- Added `abort` strings (`reauth_successful`, `reauth_failed`, `already_configured`) to `translations/en.json`
- Improved `reauth_confirm` description to be more informative

## Testing

- Deployed the fix to a live HA instance running v1.1.0
- Confirmed all 51 WHOOP entities remain active and reporting data after restart
- The fix preserves existing device associations and entity enablement states

## References

- [HA Developer Docs: Reauthentication](https://developers.home-assistant.io/docs/config_entries_config_flow_handler/#reauthentication)
- `self._get_reauth_entry()` and `self.async_update_reload_and_abort()` are the recommended HA Core patterns for reauth flows
