### PR TITLE
Fix WHOOP reauth handling

### DIFF
--- a/custom_components/whoop/__init__.py
+++ b/custom_components/whoop/__init__.py
@@ -129,6 +129,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             for i, key in enumerate(keys):
                 result_item = results[i]
                 if isinstance(result_item, Exception):
+                    if isinstance(result_item, ConfigEntryAuthFailed):
+                        raise result_item
                     _LOGGER.error("Error fetching %s: %s", key, result_item)
                 elif result_item is None:
                     _LOGGER.debug(

--- a/custom_components/whoop/config_flow.py
+++ b/custom_components/whoop/config_flow.py
@@ -97,12 +97,16 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
         access_token = data.get("token", {}).get("access_token")
         if not access_token:
             _LOGGER.error("Access token not found in OAuth data during entry creation.")
+            if self.source == config_entries.SOURCE_REAUTH:
+                return self.async_abort(reason="reauth_failed")
             return self.async_create_entry(title=self.OAUTH2_CLIENT_NAME, data=data)
 
         session = async_get_clientsession(self.hass)
         api_client = WhoopApiClient(session, access_token)
 
         entry_title_name_part = "User"
+        existing_entry = None
+        user_id = None
 
         try:
             profile = await api_client.get_user_profile_basic()
@@ -116,14 +120,28 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
                     entry_title_name_part = f"User {user_id}"
 
                 if user_id:
-                    await self.async_set_unique_id(str(user_id))
-                    self._abort_if_unique_id_configured(updates=data)
+                    existing_entry = await self.async_set_unique_id(str(user_id))
+                    if self.source != config_entries.SOURCE_REAUTH:
+                        self._abort_if_unique_id_configured(updates=data)
             else:
                 _LOGGER.warning("Could not fetch WHOOP profile to set a dynamic title.")
         except Exception as e:
             _LOGGER.error("Error fetching WHOOP profile for dynamic title: %s", e)
 
         entry_title = f"{entry_title_name_part}'s WHOOP"
+        if self.source == config_entries.SOURCE_REAUTH:
+            entry = self._get_reauth_entry()
+            if not user_id:
+                return self.async_abort(reason="reauth_failed")
+            if str(user_id) != entry.unique_id:
+                return self.async_abort(reason="wrong_account")
+            return self.async_update_reload_and_abort(
+                entry,
+                unique_id=str(user_id),
+                title=entry_title,
+                data=data,
+            )
+
         _LOGGER.info("Creating config entry with title '%s'", entry_title)
         return self.async_create_entry(
             title=entry_title,

--- a/custom_components/whoop/config_flow.py
+++ b/custom_components/whoop/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for WHOOP integration."""
 
 import logging
+from collections.abc import Mapping
 from typing import Any, Dict
 
 import voluptuous as vol
@@ -105,7 +106,6 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
         api_client = WhoopApiClient(session, access_token)
 
         entry_title_name_part = "User"
-        existing_entry = None
         user_id = None
 
         try:
@@ -120,7 +120,7 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
                     entry_title_name_part = f"User {user_id}"
 
                 if user_id:
-                    existing_entry = await self.async_set_unique_id(str(user_id))
+                    await self.async_set_unique_id(str(user_id))
                     if self.source != config_entries.SOURCE_REAUTH:
                         self._abort_if_unique_id_configured(updates=data)
             else:
@@ -133,13 +133,13 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
             entry = self._get_reauth_entry()
             if not user_id:
                 return self.async_abort(reason="reauth_failed")
-            if str(user_id) != entry.unique_id:
+            if entry.unique_id and str(user_id) != entry.unique_id:
                 return self.async_abort(reason="wrong_account")
             return self.async_update_reload_and_abort(
                 entry,
                 unique_id=str(user_id),
                 title=entry_title,
-                data=data,
+                data_updates=data,
             )
 
         _LOGGER.info("Creating config entry with title '%s'", entry_title)
@@ -152,12 +152,14 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
             },
         )
 
-    async def async_step_reauth(self, entry_data: Dict[str, Any]) -> ConfigFlowResult:
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
         """Perform reauth upon an API authentication error or explicit request."""
         _LOGGER.info(
             "[%s] Starting reauthentication flow based on entry_data.", self.handler
         )
-        return await self.async_step_reauth_confirm(entry_data)
+        return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: Dict[str, Any] | None = None

--- a/custom_components/whoop/config_flow.py
+++ b/custom_components/whoop/config_flow.py
@@ -139,7 +139,7 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
                 entry,
                 unique_id=str(user_id),
                 title=entry_title,
-                data_updates=data,
+                data=data,
             )
 
         _LOGGER.info("Creating config entry with title '%s'", entry_title)

--- a/custom_components/whoop/translations/en.json
+++ b/custom_components/whoop/translations/en.json
@@ -8,6 +8,10 @@
         "title": "Reauthenticate WHOOP",
         "description": "Please reauthenticate with your WHOOP account."
       }
+    },
+    "abort": {
+      "reauth_failed": "Reauthentication failed. Please try again.",
+      "wrong_account": "Authenticated WHOOP account does not match the account being reauthenticated."
     }
   },
   "options": {


### PR DESCRIPTION
## Summary

Fixes #18.

This fixes two auth/reauth edge cases:

- Propagate `ConfigEntryAuthFailed` out of the coordinator update when one of the gathered WHOOP API calls returns 401, so Home Assistant can start reauth instead of leaving sensors unavailable with empty data.
- During `SOURCE_REAUTH`, update and reload the existing config entry instead of calling `async_create_entry()`, which Home Assistant rejects for reauth flows.

## Root cause

`asyncio.gather(..., return_exceptions=True)` converted auth failures into result values. The update loop logged those values and continued, so Home Assistant did not receive the auth failure.

Separately, the OAuth completion path was shared by first setup and reauth, but reauth requires updating the existing config entry and aborting successfully.

## Validation

Validated on a live Home Assistant instance with this custom component:

- New OAuth token was confirmed valid against WHOOP `/developer/v2/user/profile/basic`.
- Before the fix, reauth crashed with `Creates a new entry in a 'reauth' flow...`.
- After the fix, the WHOOP config entry loaded and sensors recovered from `unavailable`.
- Ran `python3 -m py_compile` for the touched integration files.
