### PR TITLE
Harden WHOOP reauth account-identity handling

### DIFF
--- a/custom_components/whoop/config_flow.py
+++ b/custom_components/whoop/config_flow.py
@@ -108,32 +108,44 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
         entry_title_name_part = "User"
         user_id = None
 
+        # Only the profile fetch may fail benignly. Keep the unique_id /
+        # AbortFlow checks below OUTSIDE this try: AbortFlow subclasses
+        # Exception, so a broad except would swallow it and re-introduce the
+        # duplicate-entry bug.
         try:
             profile = await api_client.get_user_profile_basic()
-            if profile:
-                user_id = profile.get("user_id")
-                first_name = profile.get("first_name")
-
-                if first_name:
-                    entry_title_name_part = first_name
-                elif user_id:
-                    entry_title_name_part = f"User {user_id}"
-
-                if user_id:
-                    await self.async_set_unique_id(str(user_id))
-                    if self.source != config_entries.SOURCE_REAUTH:
-                        self._abort_if_unique_id_configured(updates=data)
-            else:
-                _LOGGER.warning("Could not fetch WHOOP profile to set a dynamic title.")
         except Exception as e:
             _LOGGER.error("Error fetching WHOOP profile for dynamic title: %s", e)
+            profile = None
+
+        if profile:
+            user_id = profile.get("user_id")
+            first_name = profile.get("first_name")
+            if first_name:
+                entry_title_name_part = first_name
+            elif user_id:
+                entry_title_name_part = f"User {user_id}"
+        else:
+            _LOGGER.warning("Could not fetch WHOOP profile to set a dynamic title.")
 
         entry_title = f"{entry_title_name_part}'s WHOOP"
+
         if self.source == config_entries.SOURCE_REAUTH:
             entry = self._get_reauth_entry()
             if not user_id:
                 return self.async_abort(reason="reauth_failed")
             if entry.unique_id and str(user_id) != entry.unique_id:
+                return self.async_abort(reason="wrong_account")
+            # Resolve the unique_id only now that we intend to proceed; this also
+            # returns any other entry already claiming this account.
+            existing_entry = await self.async_set_unique_id(str(user_id))
+            if (
+                entry.unique_id is None
+                and existing_entry is not None
+                and existing_entry.entry_id != entry.entry_id
+            ):
+                # Legacy entry that never received a unique_id, but the resolved
+                # account already belongs to another entry - don't duplicate it.
                 return self.async_abort(reason="wrong_account")
             return self.async_update_reload_and_abort(
                 entry,
@@ -141,6 +153,10 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
                 title=entry_title,
                 data=data,
             )
+
+        if user_id:
+            await self.async_set_unique_id(str(user_id))
+            self._abort_if_unique_id_configured(updates=data)
 
         _LOGGER.info("Creating config entry with title '%s'", entry_title)
         return self.async_create_entry(


### PR DESCRIPTION
Layered on top of upstream's reauth fix, trimmed to only the two items not already covered there:

- keep the unique_id / AbortFlow checks OUTSIDE the broad profile-fetch try. AbortFlow subclasses Exception, so the previous broad except swallowed _abort_if_unique_id_configured and re-introduced duplicate entries.
- handle the legacy unique_id=None reauth collision: a pre-unique_id entry whose resolved account already belongs to another entry now aborts wrong_account instead of silently duplicating.