### PR TITLE
Stop reloading the integration on every OAuth token refresh

### DIFF
--- a/custom_components/whoop/__init__.py
+++ b/custom_components/whoop/__init__.py
@@ -212,21 +212,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _apply_duration_unit_overrides(hass, entry)
 
-    # NO config entry update listener here, deliberately. Home Assistant fires
-    # update listeners on ANY change to the entry - including the hourly OAuth
-    # token write from OAuth2Session.async_ensure_token_valid() ->
-    # async_update_entry(). An update listener that reloads therefore rebuilt
-    # this integration ~24x/day, which cost 6 needless API calls per reload,
-    # punched a gap in every sensor's history, and - because
-    # ConfigEntries.async_reload() calls _abort_reauth_flows() - silently killed
-    # any reauth the user had open in a browser tab across an hour boundary.
-    #
-    # Reloading on an options change is core's job: WhoopOptionsFlowHandler
-    # subclasses OptionsFlowWithReload, so OptionsFlowManager.async_finish_flow
-    # reloads only when async_update_entry reports the options actually changed.
-    # Keeping both is an error - core raises ValueError if an update listener is
-    # registered alongside OptionsFlowWithReload, and using an update listener
-    # with async_update_reload_and_abort (the reauth path) breaks in HA 2026.12.
     return True
 
 

--- a/custom_components/whoop/__init__.py
+++ b/custom_components/whoop/__init__.py
@@ -212,16 +212,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _apply_duration_unit_overrides(hass, entry)
 
-    entry.async_on_unload(entry.add_update_listener(async_options_updated))
-
+    # NO config entry update listener here, deliberately. Home Assistant fires
+    # update listeners on ANY change to the entry - including the hourly OAuth
+    # token write from OAuth2Session.async_ensure_token_valid() ->
+    # async_update_entry(). An update listener that reloads therefore rebuilt
+    # this integration ~24x/day, which cost 6 needless API calls per reload,
+    # punched a gap in every sensor's history, and - because
+    # ConfigEntries.async_reload() calls _abort_reauth_flows() - silently killed
+    # any reauth the user had open in a browser tab across an hour boundary.
+    #
+    # Reloading on an options change is core's job: WhoopOptionsFlowHandler
+    # subclasses OptionsFlowWithReload, so OptionsFlowManager.async_finish_flow
+    # reloads only when async_update_entry reports the options actually changed.
+    # Keeping both is an error - core raises ValueError if an update listener is
+    # registered alongside OptionsFlowWithReload, and using an update listener
+    # with async_update_reload_and_abort (the reauth path) breaks in HA 2026.12.
     return True
-
-
-async def async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Handle options update - apply unit overrides and reload."""
-    _LOGGER.info("WHOOP options updated for entry: %s", entry.title)
-    _apply_duration_unit_overrides(hass, entry)
-    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/whoop/config_flow.py
+++ b/custom_components/whoop/config_flow.py
@@ -202,8 +202,15 @@ class WhoopConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
         return WhoopOptionsFlowHandler()
 
 
-class WhoopOptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle WHOOP options."""
+class WhoopOptionsFlowHandler(config_entries.OptionsFlowWithReload):
+    """Handle WHOOP options.
+
+    OptionsFlowWithReload (not plain OptionsFlow) so core reloads the entry when
+    - and only when - the options actually changed. The integration must not
+    register a config entry update listener as well: core raises ValueError if
+    both are present, and an update listener would also fire on the hourly OAuth
+    token write, reloading the integration ~24x/day. See async_setup_entry.
+    """
 
     async def async_step_init(
         self, user_input: Dict[str, Any] | None = None

--- a/hacs.json
+++ b/hacs.json
@@ -1,3 +1,4 @@
 {
-  "name": "WHOOP"
+  "name": "WHOOP",
+  "homeassistant": "2025.8.0"
 }


### PR DESCRIPTION
Nearly once-a-day I had the whoop integration token 'expire' and having to reauth with whoop.

`async_setup_entry` registers a config entry update listener that calls `async_reload()` unconditionally. Home Assistant fires update listeners on any change to the entry, including the hourly OAuth token write, so the integration tears itself down and rebuilds many times a day.

This removes the update listener and lets core handle reloading via `OptionsFlowWithReload`.

**The problem**

WHOOP access tokens live one hour. Each refresh could cause the whole integration to reload.

**HA 2026.12**

Also spotted in the logs:  `async_update_reload_and_abort()` and `_abort_if_unique_id_configured()` now emit `report_usage(..., breaks_in_ha_version="2026.12.0")` when the entry has update listeners. This integration hits `async_update_reload_and_abort` on **every reauth**, so it currently logs a deprecation each time and will break in 2026.12.

**Fix**

- Remove `entry.add_update_listener(...)` and delete `async_options_updated`
- `WhoopOptionsFlowHandler` now subclasses `config_entries.OptionsFlowWithReload`

`OptionsFlowManager.async_finish_flow` reloads only when `async_update_entry` reports the options actually changed, which is precisely the intended behaviour, implemented by core. Token writes no longer trigger anything.

**Breaking change**

`OptionsFlowWithReload` was added in **HA 2025.8.0**, so `hacs.json` now declares `"homeassistant": "2025.8.0"`. HACS will refuse to install on older cores rather than failing with an `ImportError` at runtime.


**Testing**

- Verified on a live HA 2026.7.4 instance
- Options changes still apply and reload correctly
- Reauth flow still completes and updates the existing entry

Currently still watching in my environment - will leave PR as draft for a few days until I notice better behavior.